### PR TITLE
Use build-system native for compatible Android build output paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ permissions:
 
 jobs:
   call-workflow:
-    #uses: skiptools/actions/.github/workflows/skip-framework.yml@main
-    uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
+    #uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
+    uses: skiptools/actions/.github/workflows/skip-framework.yml@main
     with:
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
       swift-android-sdk-version: "['', 'nightly-main']"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,11 @@ permissions:
 
 jobs:
   call-workflow:
+    #uses: skiptools/actions/.github/workflows/skip-framework.yml@main
     uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
     with:
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
+      swift-android-sdk-version: "['', 'nightly-main']"
       # disable export because there are currently problems with shared PCH module cache files with multi-module native export
       run-export: false
 

--- a/Sources/SkipBridge/Skip/skip.yml
+++ b/Sources/SkipBridge/Skip/skip.yml
@@ -67,7 +67,7 @@ build:
             - 'workingDir(layout.projectDirectory)'
 
             # invoke the Android build
-            - 'commandLine("sh", "-cx", "\"${skipcmd}\" android build -d \"${swiftBuildFolder()}/jni-libs\" --package-path \"${swiftSourceFolder()}\" --configuration ${mode} --product ${project.name} --scratch-path \"${swiftBuildFolder()}/swift\" --arch automatic -Xcc -fPIC -Xswiftc -DSKIP_BRIDGE -Xswiftc -DTARGET_OS_ANDROID -Xswiftc -Xfrontend -Xswiftc -no-clang-module-breadcrumbs -Xswiftc -Xfrontend -Xswiftc -module-cache-path -Xswiftc -Xfrontend -Xswiftc \"${swiftBuildFolder()}/swift/module-cache/${project.name}\"")'
+            - 'commandLine("sh", "-cx", "\"${skipcmd}\" android build -d \"${swiftBuildFolder()}/jni-libs\" --package-path \"${swiftSourceFolder()}\" --configuration ${mode} --product ${project.name} --scratch-path \"${swiftBuildFolder()}/swift\" --arch automatic --build-system native -Xcc -fPIC -Xswiftc -DSKIP_BRIDGE -Xswiftc -DTARGET_OS_ANDROID -Xswiftc -Xfrontend -Xswiftc -no-clang-module-breadcrumbs -Xswiftc -Xfrontend -Xswiftc -module-cache-path -Xswiftc -Xfrontend -Xswiftc \"${swiftBuildFolder()}/swift/module-cache/${project.name}\"")'
 
             - 'environment("SKIP_BRIDGE", "1")'
             - 'environment("TARGET_OS_ANDROID", "1")'


### PR DESCRIPTION
Stopgap measure specifies `--build-system native` while https://github.com/swiftlang/swift-build/issues/1363 is being litigated.