### PR TITLE
Fix bridging nested Function2 closures

### DIFF
--- a/Sources/SkipBridge/BridgedTypes.swift
+++ b/Sources/SkipBridge/BridgedTypes.swift
@@ -199,6 +199,36 @@ public struct AnyBridging {
         }
     }
 
+    /// Convert a Swift closure to its Java `kotlin.jvm.functions.Function0` form.
+    public static func toJavaObject<R>(_ value: (() throws -> R)?, options: JConvertibleOptions) -> JavaObjectPointer? {
+        SwiftClosure0.javaObject(for: value, options: options)
+    }
+
+    /// Convert a Swift closure to its Java `kotlin.jvm.functions.Function1` form.
+    public static func toJavaObject<P0, R>(_ value: ((P0) throws -> R)?, options: JConvertibleOptions) -> JavaObjectPointer? {
+        SwiftClosure1.javaObject(for: value, options: options)
+    }
+
+    /// Convert a Swift closure to its Java `kotlin.jvm.functions.Function2` form.
+    public static func toJavaObject<P0, P1, R>(_ value: ((P0, P1) throws -> R)?, options: JConvertibleOptions) -> JavaObjectPointer? {
+        SwiftClosure2.javaObject(for: value, options: options)
+    }
+
+    /// Convert a Swift closure to its Java `kotlin.jvm.functions.Function3` form.
+    public static func toJavaObject<P0, P1, P2, R>(_ value: ((P0, P1, P2) throws -> R)?, options: JConvertibleOptions) -> JavaObjectPointer? {
+        SwiftClosure3.javaObject(for: value, options: options)
+    }
+
+    /// Convert a Swift closure to its Java `kotlin.jvm.functions.Function4` form.
+    public static func toJavaObject<P0, P1, P2, P3, R>(_ value: ((P0, P1, P2, P3) throws -> R)?, options: JConvertibleOptions) -> JavaObjectPointer? {
+        SwiftClosure4.javaObject(for: value, options: options)
+    }
+
+    /// Convert a Swift closure to its Java `kotlin.jvm.functions.Function5` form.
+    public static func toJavaObject<P0, P1, P2, P3, P4, R>(_ value: ((P0, P1, P2, P3, P4) throws -> R)?, options: JConvertibleOptions) -> JavaObjectPointer? {
+        SwiftClosure5.javaObject(for: value, options: options)
+    }
+
     /// Convert a Kotlin/Java instance of a known base type to its Swift projection.
     public static func fromJavaObject<T>(_ ptr: JavaObjectPointer?, toBaseType: T.Type, options: JConvertibleOptions) -> T? {
         guard let ptr else {

--- a/Sources/SkipBridge/Closures.swift
+++ b/Sources/SkipBridge/Closures.swift
@@ -70,7 +70,7 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
         }
     }
 
-    public func invokeJava(_ p0: JavaObjectPointer?, _ p1: JavaObjectPointer?) throws -> R {
+    func invokeJava(_ p0: JavaObjectPointer?, _ p1: JavaObjectPointer?) throws -> R {
         return try jniContext {
             let object: JavaObjectPointer? = try call(method: Java_Function2_invoke_methodID, options: options, args: [
                 p0.toJavaParameter(options: options),
@@ -399,7 +399,7 @@ public final class SwiftClosure2 {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0, p1 in
                 let p0_java = AnyBridging.toJavaObject(p0, options: options)
-                let p1_java = SwiftClosure1.javaObject(for: p1, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
                 return try! closure.invokeJava(p0_java, p1_java)
             }
         }
@@ -430,7 +430,7 @@ public final class SwiftClosure2 {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0, p1 in
                 let p0_java = AnyBridging.toJavaObject(p0, options: options)
-                let p1_java = SwiftClosure1.javaObject(for: p1, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
                 return try closure.invokeJava(p0_java, p1_java)
             }
         }

--- a/Sources/SkipBridge/Closures.swift
+++ b/Sources/SkipBridge/Closures.swift
@@ -70,6 +70,16 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
         }
     }
 
+    public func invokeJava(_ p0: JavaObjectPointer?, _ p1: JavaObjectPointer?) throws -> R {
+        return try jniContext {
+            let object: JavaObjectPointer? = try call(method: Java_Function2_invoke_methodID, options: options, args: [
+                p0.toJavaParameter(options: options),
+                p1.toJavaParameter(options: options),
+            ])
+            return returnValue(for: object)
+        }
+    }
+
     public func invokeSuspend(_ p0: Any?, _ p1: Any?) async throws -> R {
         return try await invokeSuspendContinuation { continuation in
             let p0_java = AnyBridging.toJavaObject(p0, options: options).toJavaParameter(options: options)
@@ -364,6 +374,7 @@ public final class SwiftClosure2 {
         return javaObject(for: { p0, p1 in try MainActor.assumeIsolated { try closure(p0, p1) } }, options: options)
     }
 
+    @_disfavoredOverload
     public static func closure<P0, P1, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, P1) -> R)? {
         guard let function else {
             return nil
@@ -377,6 +388,24 @@ public final class SwiftClosure2 {
         }
     }
 
+    public static func closure<P0, C0, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0) -> CR) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try! closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = SwiftClosure1.javaObject(for: p1, options: options)
+                return try! closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    @_disfavoredOverload
     public static func closure<P0, P1, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, P1) throws -> R)? {
         guard let function else {
             return nil
@@ -387,6 +416,23 @@ public final class SwiftClosure2 {
         } else {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0, p1 in try closure.invoke(p0, p1) }
+        }
+    }
+
+    public static func closure<P0, C0, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0) -> CR) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = SwiftClosure1.javaObject(for: p1, options: options)
+                return try closure.invokeJava(p0_java, p1_java)
+            }
         }
     }
 

--- a/Sources/SkipBridge/Closures.swift
+++ b/Sources/SkipBridge/Closures.swift
@@ -388,7 +388,92 @@ public final class SwiftClosure2 {
         }
     }
 
+    public static func closure<P0, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping () -> CR) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try! closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try! closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
     public static func closure<P0, C0, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0) -> CR) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try! closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try! closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1) -> CR) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try! closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try! closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, C2, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1, C2) -> CR) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try! closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try! closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, C2, C3, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1, C2, C3) -> CR) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try! closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try! closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, C2, C3, C4, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1, C2, C3, C4) -> CR) -> R)? {
         guard let function else {
             return nil
         }
@@ -419,7 +504,92 @@ public final class SwiftClosure2 {
         }
     }
 
+    public static func closure<P0, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping () throws -> CR) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
     public static func closure<P0, C0, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0) -> CR) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1) throws -> CR) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, C2, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1, C2) throws -> CR) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, C2, C3, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1, C2, C3) throws -> CR) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in
+                let p0_java = AnyBridging.toJavaObject(p0, options: options)
+                let p1_java = AnyBridging.toJavaObject(p1, options: options)
+                return try closure.invokeJava(p0_java, p1_java)
+            }
+        }
+    }
+
+    public static func closure<P0, C0, C1, C2, C3, C4, CR, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, @escaping (C0, C1, C2, C3, C4) throws -> CR) throws -> R)? {
         guard let function else {
             return nil
         }

--- a/Sources/SkipBridgeToKotlinCompatSamples/Samples.swift
+++ b/Sources/SkipBridgeToKotlinCompatSamples/Samples.swift
@@ -9,6 +9,8 @@ public class Compat {
     public var result: Result<String, Error>?
     public var errorvar: Error = CompatError()
     public var locale = Locale.current
+    public var nestedURLCallback: (URL?, @escaping (URL) -> Void) -> Void = { _, _ in }
+    public var nestedURLCallbackValue: URL?
 
     public init(id: UUID) {
         self.id = id
@@ -28,6 +30,12 @@ public class Compat {
             collected.append(value)
         }
         return collected
+    }
+
+    public func invokeNestedURLCallback(with url: URL?) {
+        nestedURLCallback(url) { [weak self] updatedURL in
+            self?.nestedURLCallbackValue = updatedURL
+        }
     }
 }
 

--- a/Sources/SkipBridgeToKotlinCompatSamples/Samples.swift
+++ b/Sources/SkipBridgeToKotlinCompatSamples/Samples.swift
@@ -9,8 +9,18 @@ public class Compat {
     public var result: Result<String, Error>?
     public var errorvar: Error = CompatError()
     public var locale = Locale.current
+    public var nestedURLCallback0: (URL?, @escaping () -> URL) -> Void = { _, _ in }
     public var nestedURLCallback: (URL?, @escaping (URL) -> Void) -> Void = { _, _ in }
+    public var nestedURLCallback2: (URL?, @escaping (Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback3: (URL?, @escaping (Int, Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback4: (URL?, @escaping (Int, Int, Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback5: (URL?, @escaping (Int, Int, Int, Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback0Value: URL?
     public var nestedURLCallbackValue: URL?
+    public var nestedURLCallback2Value: URL?
+    public var nestedURLCallback3Value: URL?
+    public var nestedURLCallback4Value: URL?
+    public var nestedURLCallback5Value: URL?
 
     public init(id: UUID) {
         self.id = id
@@ -35,6 +45,46 @@ public class Compat {
     public func invokeNestedURLCallback(with url: URL?) {
         nestedURLCallback(url) { [weak self] updatedURL in
             self?.nestedURLCallbackValue = updatedURL
+        }
+    }
+
+    public func invokeNestedURLCallback0(with url: URL?) {
+        nestedURLCallback0(url) { [weak self] in
+            let result = URL(string: "https://skip.dev/callback0")!
+            self?.nestedURLCallback0Value = result
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback2(with url: URL?) {
+        nestedURLCallback2(url) { [weak self] i0, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0)")!
+            self?.nestedURLCallback2Value = updatedURL
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback3(with url: URL?) {
+        nestedURLCallback3(url) { [weak self] i0, i1, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0 + i1)")!
+            self?.nestedURLCallback3Value = updatedURL
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback4(with url: URL?) {
+        nestedURLCallback4(url) { [weak self] i0, i1, i2, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0 + i1 + i2)")!
+            self?.nestedURLCallback4Value = updatedURL
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback5(with url: URL?) {
+        nestedURLCallback5(url) { [weak self] i0, i1, i2, i3, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0 + i1 + i2 + i3)")!
+            self?.nestedURLCallback5Value = updatedURL
+            return result
         }
     }
 }

--- a/Tests/SkipBridgeToKotlinCompatSamplesTests/BridgeToKotlinCompatSamplesTests.swift
+++ b/Tests/SkipBridgeToKotlinCompatSamplesTests/BridgeToKotlinCompatSamplesTests.swift
@@ -111,4 +111,65 @@ final class BridgeToKotlinCompatTests: XCTestCase {
         XCTAssertEqual(compat.nestedURLCallbackValue, updatedURL)
         #endif
     }
+
+    func testCompatNestedClosureCallbackArities() {
+        #if SKIP
+        let compat = Compat(id: java.util.UUID.randomUUID())
+        let originalURL = java.net.URI("https://skip.dev/original")
+        let updatedURL = java.net.URI("https://skip.dev/updated")
+        var receivedURL0: java.net.URI?
+        var receivedURL2: java.net.URI?
+        var receivedURL3: java.net.URI?
+        var receivedURL4: java.net.URI?
+        var receivedURL5: java.net.URI?
+        var returnedURL0: java.net.URI?
+        var returnedURL2: java.net.URI?
+        var returnedURL3: java.net.URI?
+        var returnedURL4: java.net.URI?
+        var returnedURL5: java.net.URI?
+
+        compat.nestedURLCallback0 = { currentURL, completion in
+            receivedURL0 = currentURL
+            returnedURL0 = completion()
+        }
+        compat.nestedURLCallback2 = { currentURL, completion in
+            receivedURL2 = currentURL
+            returnedURL2 = completion(2, updatedURL)
+        }
+        compat.nestedURLCallback3 = { currentURL, completion in
+            receivedURL3 = currentURL
+            returnedURL3 = completion(2, 3, updatedURL)
+        }
+        compat.nestedURLCallback4 = { currentURL, completion in
+            receivedURL4 = currentURL
+            returnedURL4 = completion(2, 3, 4, updatedURL)
+        }
+        compat.nestedURLCallback5 = { currentURL, completion in
+            receivedURL5 = currentURL
+            returnedURL5 = completion(2, 3, 4, 5, updatedURL)
+        }
+
+        compat.invokeNestedURLCallback0(with: originalURL)
+        compat.invokeNestedURLCallback2(with: originalURL)
+        compat.invokeNestedURLCallback3(with: originalURL)
+        compat.invokeNestedURLCallback4(with: originalURL)
+        compat.invokeNestedURLCallback5(with: originalURL)
+
+        XCTAssertEqual(receivedURL0, originalURL)
+        XCTAssertEqual(receivedURL2, originalURL)
+        XCTAssertEqual(receivedURL3, originalURL)
+        XCTAssertEqual(receivedURL4, originalURL)
+        XCTAssertEqual(receivedURL5, originalURL)
+        XCTAssertEqual(compat.nestedURLCallback0Value, java.net.URI("https://skip.dev/callback0"))
+        XCTAssertEqual(compat.nestedURLCallback2Value, updatedURL)
+        XCTAssertEqual(compat.nestedURLCallback3Value, updatedURL)
+        XCTAssertEqual(compat.nestedURLCallback4Value, updatedURL)
+        XCTAssertEqual(compat.nestedURLCallback5Value, updatedURL)
+        XCTAssertEqual(returnedURL0, java.net.URI("https://skip.dev/callback0"))
+        XCTAssertEqual(returnedURL2, java.net.URI("https://skip.dev/callback2"))
+        XCTAssertEqual(returnedURL3, java.net.URI("https://skip.dev/callback5"))
+        XCTAssertEqual(returnedURL4, java.net.URI("https://skip.dev/callback9"))
+        XCTAssertEqual(returnedURL5, java.net.URI("https://skip.dev/callback14"))
+        #endif
+    }
 }

--- a/Tests/SkipBridgeToKotlinCompatSamplesTests/BridgeToKotlinCompatSamplesTests.swift
+++ b/Tests/SkipBridgeToKotlinCompatSamplesTests/BridgeToKotlinCompatSamplesTests.swift
@@ -92,4 +92,23 @@ final class BridgeToKotlinCompatTests: XCTestCase {
         XCTAssertEqual(collected2, listOf(100, 200))
         #endif
     }
+
+    func testCompatNestedClosureCallback() {
+        #if SKIP
+        let compat = Compat(id: java.util.UUID.randomUUID())
+        let originalURL = java.net.URI("https://skip.dev/original")
+        let updatedURL = java.net.URI("https://skip.dev/updated")
+        var receivedURL: java.net.URI?
+
+        compat.nestedURLCallback = { currentURL, completion in
+            receivedURL = currentURL
+            completion(updatedURL)
+        }
+
+        compat.invokeNestedURLCallback(with: originalURL)
+
+        XCTAssertEqual(receivedURL, originalURL)
+        XCTAssertEqual(compat.nestedURLCallbackValue, updatedURL)
+        #endif
+    }
 }


### PR DESCRIPTION
## Summary
- Fix Java-backed `SwiftClosure2` invocation when the second argument is an escaping Swift closure.
- Add typed `AnyBridging.toJavaObject` overloads for Swift closures so closure-to-`kotlin.jvm.functions.FunctionN` conversion lives in the generic bridge surface.
- Keep the nested callback overload as the typed dispatch point needed before Swift erases the closure to `Any`.
- Add a kotlincompat regression test for `(URL?, @escaping (URL) -> Void) -> Void`.

## Root Cause
The generic arity-2 Java-backed closure bridge converted every argument through the erased `Any?` bridge. When one argument was itself a Swift closure, the erased bridge hit the fatal assertion for `Function` instances before Java/Kotlin could invoke the callback.

Swift does not expose enough callable metadata to safely rewrap an arbitrary closure after it has already been erased to `Any`, so the fix preserves the typed closure at the overload boundary and routes the actual conversion through `AnyBridging.toJavaObject`.

## Validation
- `swift test --filter BridgeToKotlinCompatTests`
- `swift test --filter SkipBridgeToKotlinCompatSamplesTests.XCSkipTests/testSkipModule`
