### PR TITLE
Bridge closure properties whose parameters are closures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # TODO: remove
       # local build of skipstone with 'bridge-closure-arg' branch
-      skip-source: 'bridge-closure-arg'
+      skip-source: 'main'
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
       swift-android-sdk-version: "['', 'nightly-main']"
       # disable export because there are currently problems with shared PCH module cache files with multi-module native export

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   call-workflow:
     uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
     with:
+      # TODO: remove
+      # local build of skipstone with 'bridge-closure-arg' branch
+      skip-source: 'bridge-closure-arg'
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
       swift-android-sdk-version: "['', 'nightly-main']"
       # disable export because there are currently problems with shared PCH module cache files with multi-module native export

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
   call-workflow:
     uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
     with:
-      # TODO: remove
-      # local build of skipstone with 'bridge-closure-arg' branch
-      skip-source: 'main'
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
       swift-android-sdk-version: "['', 'nightly-main']"
       # disable export because there are currently problems with shared PCH module cache files with multi-module native export

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,10 @@ let package = Package(
         .library(name: "SkipBridgeToSwiftSamplesTestsSupport", type: .dynamic, targets: ["SkipBridgeToSwiftSamplesTestsSupport"]),
     ],
     dependencies: [
-        .package(url: "https://source.skip.tools/skip.git", from: "1.6.35"),
-        .package(url: "https://source.skip.tools/skip-lib.git", from: "1.3.8"),
-        .package(url: "https://source.skip.tools/skip-foundation.git", from: "1.3.10"),
-        .package(url: "https://source.skip.tools/swift-jni.git", "0.3.1"..<"2.0.0"),
+        .package(url: "https://source.skip.tools/skip.git", from: "1.8.17"),
+        .package(url: "https://source.skip.tools/skip-lib.git", from: "1.4.0"),
+        .package(url: "https://source.skip.tools/skip-foundation.git", from: "1.4.0"),
+        .package(url: "https://source.skip.tools/swift-jni.git", "0.5.0"..<"2.0.0"),
     ],
     targets: [
         .target(name: "SkipBridge",

--- a/Sources/SkipBridge/Closures.swift
+++ b/Sources/SkipBridge/Closures.swift
@@ -18,6 +18,13 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
         }
     }
 
+    public func invokeJava() throws -> R {
+        return try jniContext {
+            let object: JavaObjectPointer? = try call(method: Java_Function0_invoke_methodID, options: options, args: [])
+            return returnValue(for: object)
+        }
+    }
+
     /// Invokes the given block within a continuation that adapts to a `kotlin.coroutines.Continuation`
     private func invokeSuspendContinuation(_ closure: (_ continuation: JavaObjectPointer) throws -> ()) async throws -> R {
         return try await withCheckedThrowingContinuation { swiftContinuation in
@@ -54,6 +61,15 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
         }
     }
 
+    public func invokeJava(_ p0: JavaObjectPointer?) throws -> R {
+        return try jniContext {
+            let object: JavaObjectPointer? = try call(method: Java_Function1_invoke_methodID, options: options, args: [
+                p0.toJavaParameter(options: options),
+            ])
+            return returnValue(for: object)
+        }
+    }
+
     public func invokeSuspend(_ p0: Any?) async throws -> R {
         return try await invokeSuspendContinuation { continuation in
             let p0_java = AnyBridging.toJavaObject(p0, options: options).toJavaParameter(options: options)
@@ -66,6 +82,16 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
             let p0_java = AnyBridging.toJavaObject(p0, options: options).toJavaParameter(options: options)
             let p1_java = AnyBridging.toJavaObject(p1, options: options).toJavaParameter(options: options)
             let object: JavaObjectPointer? = try call(method: Java_Function2_invoke_methodID, options: options, args: [p0_java, p1_java])
+            return returnValue(for: object)
+        }
+    }
+
+    public func invokeJava(_ p0: JavaObjectPointer?, _ p1: JavaObjectPointer?) throws -> R {
+        return try jniContext {
+            let object: JavaObjectPointer? = try call(method: Java_Function2_invoke_methodID, options: options, args: [
+                p0.toJavaParameter(options: options),
+                p1.toJavaParameter(options: options),
+            ])
             return returnValue(for: object)
         }
     }
@@ -84,6 +110,17 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
             let p1_java = AnyBridging.toJavaObject(p1, options: options).toJavaParameter(options: options)
             let p2_java = AnyBridging.toJavaObject(p2, options: options).toJavaParameter(options: options)
             let object: JavaObjectPointer? = try call(method: Java_Function3_invoke_methodID, options: options, args: [p0_java, p1_java, p2_java])
+            return returnValue(for: object)
+        }
+    }
+
+    public func invokeJava(_ p0: JavaObjectPointer?, _ p1: JavaObjectPointer?, _ p2: JavaObjectPointer?) throws -> R {
+        return try jniContext {
+            let object: JavaObjectPointer? = try call(method: Java_Function3_invoke_methodID, options: options, args: [
+                p0.toJavaParameter(options: options),
+                p1.toJavaParameter(options: options),
+                p2.toJavaParameter(options: options),
+            ])
             return returnValue(for: object)
         }
     }
@@ -108,6 +145,18 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
         }
     }
 
+    public func invokeJava(_ p0: JavaObjectPointer?, _ p1: JavaObjectPointer?, _ p2: JavaObjectPointer?, _ p3: JavaObjectPointer?) throws -> R {
+        return try jniContext {
+            let object: JavaObjectPointer? = try call(method: Java_Function4_invoke_methodID, options: options, args: [
+                p0.toJavaParameter(options: options),
+                p1.toJavaParameter(options: options),
+                p2.toJavaParameter(options: options),
+                p3.toJavaParameter(options: options),
+            ])
+            return returnValue(for: object)
+        }
+    }
+
     public func invokeSuspend(_ p0: Any?, _ p1: Any?, _ p2: Any?, _ p3: Any?) async throws -> R {
         return try await invokeSuspendContinuation { continuation in
             let p0_java = AnyBridging.toJavaObject(p0, options: options).toJavaParameter(options: options)
@@ -126,6 +175,19 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
             let p3_java = AnyBridging.toJavaObject(p3, options: options).toJavaParameter(options: options)
             let p4_java = AnyBridging.toJavaObject(p4, options: options).toJavaParameter(options: options)
             let object: JavaObjectPointer? = try call(method: Java_Function5_invoke_methodID, options: options, args: [p0_java, p1_java, p2_java, p3_java, p4_java])
+            return returnValue(for: object)
+        }
+    }
+
+    public func invokeJava(_ p0: JavaObjectPointer?, _ p1: JavaObjectPointer?, _ p2: JavaObjectPointer?, _ p3: JavaObjectPointer?, _ p4: JavaObjectPointer?) throws -> R {
+        return try jniContext {
+            let object: JavaObjectPointer? = try call(method: Java_Function5_invoke_methodID, options: options, args: [
+                p0.toJavaParameter(options: options),
+                p1.toJavaParameter(options: options),
+                p2.toJavaParameter(options: options),
+                p3.toJavaParameter(options: options),
+                p4.toJavaParameter(options: options),
+            ])
             return returnValue(for: object)
         }
     }
@@ -307,6 +369,19 @@ public final class SwiftClosure1 {
         }
     }
 
+    public static func closure<P0, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0) throws -> R) -> (@Sendable (P0) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure1 = ptr.pointee()!
+            return { p0 in try! closure.closure(p0) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0 in try! invokeJava(closure, p0) }
+        }
+    }
+
     public static func closure<P0, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0) throws -> R)? {
         guard let function else {
             return nil
@@ -317,6 +392,19 @@ public final class SwiftClosure1 {
         } else {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0 in try closure.invoke(p0) }
+        }
+    }
+
+    public static func closure<P0, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0) throws -> R) -> (@Sendable (P0) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure1 = ptr.pointee()!
+            return { p0 in try closure.closure(p0) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0 in try invokeJava(closure, p0) }
         }
     }
 
@@ -377,6 +465,19 @@ public final class SwiftClosure2 {
         }
     }
 
+    public static func closure<P0, P1, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1) throws -> R) -> (@Sendable (P0, P1) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try! closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in try! invokeJava(closure, p0, p1) }
+        }
+    }
+
     public static func closure<P0, P1, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, P1) throws -> R)? {
         guard let function else {
             return nil
@@ -387,6 +488,19 @@ public final class SwiftClosure2 {
         } else {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0, p1 in try closure.invoke(p0, p1) }
+        }
+    }
+
+    public static func closure<P0, P1, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1) throws -> R) -> (@Sendable (P0, P1) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure2 = ptr.pointee()!
+            return { p0, p1 in try closure.closure(p0, p1) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1 in try invokeJava(closure, p0, p1) }
         }
     }
 
@@ -450,6 +564,19 @@ public final class SwiftClosure3 {
         }
     }
 
+    public static func closure<P0, P1, P2, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1, P2) throws -> R) -> (@Sendable (P0, P1, P2) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure3 = ptr.pointee()!
+            return { p0, p1, p2 in try! closure.closure(p0, p1, p2) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1, p2 in try! invokeJava(closure, p0, p1, p2) }
+        }
+    }
+
     public static func closure<P0, P1, P2, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, P1, P2) throws -> R)? {
         guard let function else {
             return nil
@@ -460,6 +587,19 @@ public final class SwiftClosure3 {
         } else {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0, p1, p2 in try closure.invoke(p0, p1, p2) }
+        }
+    }
+
+    public static func closure<P0, P1, P2, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1, P2) throws -> R) -> (@Sendable (P0, P1, P2) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure3 = ptr.pointee()!
+            return { p0, p1, p2 in try closure.closure(p0, p1, p2) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1, p2 in try invokeJava(closure, p0, p1, p2) }
         }
     }
 
@@ -526,6 +666,19 @@ public final class SwiftClosure4 {
         }
     }
 
+    public static func closure<P0, P1, P2, P3, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1, P2, P3) throws -> R) -> (@Sendable (P0, P1, P2, P3) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure4 = ptr.pointee()!
+            return { p0, p1, p2, p3 in try! closure.closure(p0, p1, p2, p3) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1, p2, p3 in try! invokeJava(closure, p0, p1, p2, p3) }
+        }
+    }
+
     public static func closure<P0, P1, P2, P3, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, P1, P2, P3) throws -> R)? {
         guard let function else {
             return nil
@@ -536,6 +689,19 @@ public final class SwiftClosure4 {
         } else {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0, p1, p2, p3 in try closure.invoke(p0, p1, p2, p3) }
+        }
+    }
+
+    public static func closure<P0, P1, P2, P3, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1, P2, P3) throws -> R) -> (@Sendable (P0, P1, P2, P3) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure4 = ptr.pointee()!
+            return { p0, p1, p2, p3 in try closure.closure(p0, p1, p2, p3) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1, p2, p3 in try invokeJava(closure, p0, p1, p2, p3) }
         }
     }
 
@@ -605,6 +771,19 @@ public final class SwiftClosure5 {
         }
     }
 
+    public static func closure<P0, P1, P2, P3, P4, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1, P2, P3, P4) throws -> R) -> (@Sendable (P0, P1, P2, P3, P4) -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure5 = ptr.pointee()!
+            return { p0, p1, p2, p3, p4 in try! closure.closure(p0, p1, p2, p3, p4) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1, p2, p3, p4 in try! invokeJava(closure, p0, p1, p2, p3, p4) }
+        }
+    }
+
     public static func closure<P0, P1, P2, P3, P4, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions) -> (@Sendable (P0, P1, P2, P3, P4) throws -> R)? {
         guard let function else {
             return nil
@@ -615,6 +794,19 @@ public final class SwiftClosure5 {
         } else {
             let closure = JavaBackedClosure<R>(function, options: options)
             return { p0, p1, p2, p3, p4 in try closure.invoke(p0, p1, p2, p3, p4) }
+        }
+    }
+
+    public static func closure<P0, P1, P2, P3, P4, R>(forJavaObject function: JavaObjectPointer?, options: JConvertibleOptions, invokeJava: @escaping @Sendable (JavaBackedClosure<R>, P0, P1, P2, P3, P4) throws -> R) -> (@Sendable (P0, P1, P2, P3, P4) throws -> R)? {
+        guard let function else {
+            return nil
+        }
+        if let ptr = SwiftObjectPointer.tryPeer(of: function, options: options) {
+            let closure: SwiftClosure5 = ptr.pointee()!
+            return { p0, p1, p2, p3, p4 in try closure.closure(p0, p1, p2, p3, p4) as! R }
+        } else {
+            let closure = JavaBackedClosure<R>(function, options: options)
+            return { p0, p1, p2, p3, p4 in try invokeJava(closure, p0, p1, p2, p3, p4) }
         }
     }
 

--- a/Sources/SkipBridgeToKotlinCompatSamples/Samples.swift
+++ b/Sources/SkipBridgeToKotlinCompatSamples/Samples.swift
@@ -9,6 +9,18 @@ public class Compat {
     public var result: Result<String, Error>?
     public var errorvar: Error = CompatError()
     public var locale = Locale.current
+    public var nestedURLCallback0: (URL?, @escaping () -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback: (URL?, @escaping (URL) -> Void) -> Void = { _, _ in }
+    public var nestedURLCallback2: (URL?, @escaping (Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback3: (URL?, @escaping (Int, Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback4: (URL?, @escaping (Int, Int, Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback5: (URL?, @escaping (Int, Int, Int, Int, URL) -> URL) -> Void = { _, _ in }
+    public var nestedURLCallback0Value: URL?
+    public var nestedURLCallbackValue: URL?
+    public var nestedURLCallback2Value: URL?
+    public var nestedURLCallback3Value: URL?
+    public var nestedURLCallback4Value: URL?
+    public var nestedURLCallback5Value: URL?
 
     public init(id: UUID) {
         self.id = id
@@ -28,6 +40,52 @@ public class Compat {
             collected.append(value)
         }
         return collected
+    }
+
+    public func invokeNestedURLCallback(with url: URL?) {
+        nestedURLCallback(url) { [weak self] updatedURL in
+            self?.nestedURLCallbackValue = updatedURL
+        }
+    }
+
+    public func invokeNestedURLCallback0(with url: URL?) {
+        nestedURLCallback0(url) { [weak self] in
+            let result = URL(string: "https://skip.dev/callback0")!
+            self?.nestedURLCallback0Value = result
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback2(with url: URL?) {
+        nestedURLCallback2(url) { [weak self] i0, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0)")!
+            self?.nestedURLCallback2Value = updatedURL
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback3(with url: URL?) {
+        nestedURLCallback3(url) { [weak self] i0, i1, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0 + i1)")!
+            self?.nestedURLCallback3Value = updatedURL
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback4(with url: URL?) {
+        nestedURLCallback4(url) { [weak self] i0, i1, i2, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0 + i1 + i2)")!
+            self?.nestedURLCallback4Value = updatedURL
+            return result
+        }
+    }
+
+    public func invokeNestedURLCallback5(with url: URL?) {
+        nestedURLCallback5(url) { [weak self] i0, i1, i2, i3, updatedURL in
+            let result = URL(string: "https://skip.dev/callback\(i0 + i1 + i2 + i3)")!
+            self?.nestedURLCallback5Value = updatedURL
+            return result
+        }
     }
 }
 

--- a/Tests/SkipBridgeToKotlinCompatSamplesTests/BridgeToKotlinCompatSamplesTests.swift
+++ b/Tests/SkipBridgeToKotlinCompatSamplesTests/BridgeToKotlinCompatSamplesTests.swift
@@ -92,4 +92,84 @@ final class BridgeToKotlinCompatTests: XCTestCase {
         XCTAssertEqual(collected2, listOf(100, 200))
         #endif
     }
+
+    func testCompatNestedClosureCallback() {
+        #if SKIP
+        let compat = Compat(id: java.util.UUID.randomUUID())
+        let originalURL = java.net.URI("https://skip.dev/original")
+        let updatedURL = java.net.URI("https://skip.dev/updated")
+        var receivedURL: java.net.URI?
+
+        compat.nestedURLCallback = { currentURL, completion in
+            receivedURL = currentURL
+            completion(updatedURL)
+        }
+
+        compat.invokeNestedURLCallback(with: originalURL)
+
+        XCTAssertEqual(receivedURL, originalURL)
+        XCTAssertEqual(compat.nestedURLCallbackValue, updatedURL)
+        #endif
+    }
+
+    func testCompatNestedClosureCallbackArities() {
+        #if SKIP
+        let compat = Compat(id: java.util.UUID.randomUUID())
+        let originalURL = java.net.URI("https://skip.dev/original")
+        let updatedURL = java.net.URI("https://skip.dev/updated")
+        var receivedURL0: java.net.URI?
+        var receivedURL2: java.net.URI?
+        var receivedURL3: java.net.URI?
+        var receivedURL4: java.net.URI?
+        var receivedURL5: java.net.URI?
+        var returnedURL0: java.net.URI?
+        var returnedURL2: java.net.URI?
+        var returnedURL3: java.net.URI?
+        var returnedURL4: java.net.URI?
+        var returnedURL5: java.net.URI?
+
+        compat.nestedURLCallback0 = { currentURL, completion in
+            receivedURL0 = currentURL
+            returnedURL0 = completion()
+        }
+        compat.nestedURLCallback2 = { currentURL, completion in
+            receivedURL2 = currentURL
+            returnedURL2 = completion(2, updatedURL)
+        }
+        compat.nestedURLCallback3 = { currentURL, completion in
+            receivedURL3 = currentURL
+            returnedURL3 = completion(2, 3, updatedURL)
+        }
+        compat.nestedURLCallback4 = { currentURL, completion in
+            receivedURL4 = currentURL
+            returnedURL4 = completion(2, 3, 4, updatedURL)
+        }
+        compat.nestedURLCallback5 = { currentURL, completion in
+            receivedURL5 = currentURL
+            returnedURL5 = completion(2, 3, 4, 5, updatedURL)
+        }
+
+        compat.invokeNestedURLCallback0(with: originalURL)
+        compat.invokeNestedURLCallback2(with: originalURL)
+        compat.invokeNestedURLCallback3(with: originalURL)
+        compat.invokeNestedURLCallback4(with: originalURL)
+        compat.invokeNestedURLCallback5(with: originalURL)
+
+        XCTAssertEqual(receivedURL0, originalURL)
+        XCTAssertEqual(receivedURL2, originalURL)
+        XCTAssertEqual(receivedURL3, originalURL)
+        XCTAssertEqual(receivedURL4, originalURL)
+        XCTAssertEqual(receivedURL5, originalURL)
+        XCTAssertEqual(compat.nestedURLCallback0Value, java.net.URI("https://skip.dev/callback0"))
+        XCTAssertEqual(compat.nestedURLCallback2Value, updatedURL)
+        XCTAssertEqual(compat.nestedURLCallback3Value, updatedURL)
+        XCTAssertEqual(compat.nestedURLCallback4Value, updatedURL)
+        XCTAssertEqual(compat.nestedURLCallback5Value, updatedURL)
+        XCTAssertEqual(returnedURL0, java.net.URI("https://skip.dev/callback0"))
+        XCTAssertEqual(returnedURL2, java.net.URI("https://skip.dev/callback2"))
+        XCTAssertEqual(returnedURL3, java.net.URI("https://skip.dev/callback5"))
+        XCTAssertEqual(returnedURL4, java.net.URI("https://skip.dev/callback9"))
+        XCTAssertEqual(returnedURL5, java.net.URI("https://skip.dev/callback14"))
+        #endif
+    }
 }


### PR DESCRIPTION
This is an alternative solution to https://github.com/skiptools/skip-bridge/pull/108 which relies on a skipstone change in the bridge generation. It has the advantage of not being limited to a single fixed positional parameter that is the closure, and instead can be applied generically for any closure parameter.

Requires https://github.com/skiptools/skipstone/pull/249
Supersedes and closes https://github.com/skiptools/skip-bridge/pull/108
