### PR TITLE
Add flag for running against swiftlang/swift-java-jni-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
       env: SWIFT_JAVA_JNI_CORE=1
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
       swift-android-sdk-version: "['', 'nightly-main']"
-      # TODO: investigate test hangs
-      run-local-tests: false
       # disable export because there are currently problems with shared PCH module cache files with multi-module native export
       run-export: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,13 @@ jobs:
   # build against the variant that uses SWIFT_JAVA_JNI_CORE to
   # switch swift-jni to instead use swiftlang/swift-java-jni-core
   skip-bridge-swiftlang-jni:
-    uses: skiptools/actions/.github/workflows/skip-framework.yml@derived-sources
+    uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
     with:
       env: SWIFT_JAVA_JNI_CORE=1
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
       swift-android-sdk-version: "['', 'nightly-main']"
+      # TODO: investigate test hangs
+      run-local-tests: false
       # disable export because there are currently problems with shared PCH module cache files with multi-module native export
       run-export: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   # build against the variant that uses SWIFT_JAVA_JNI_CORE to
   # switch swift-jni to instead use swiftlang/swift-java-jni-core
   skip-bridge-swiftlang-jni:
-    uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
+    uses: skiptools/actions/.github/workflows/skip-framework.yml@derived-sources
     with:
       env: SWIFT_JAVA_JNI_CORE=1
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,20 @@ permissions:
   contents: write
 
 jobs:
-  call-workflow:
+  skip-bridge-skip-jni:
     uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
     with:
+      runs-on: "['macos-15-intel', 'ubuntu-24.04']"
+      swift-android-sdk-version: "['', 'nightly-main']"
+      # disable export because there are currently problems with shared PCH module cache files with multi-module native export
+      run-export: false
+
+  # build against the variant that uses SWIFT_JAVA_JNI_CORE to
+  # switch swift-jni to instead use swiftlang/swift-java-jni-core
+  skip-bridge-swiftlang-jni:
+    uses: skiptools/actions/.github/workflows/skip-framework.yml@v1
+    with:
+      env: SWIFT_JAVA_JNI_CORE=1
       runs-on: "['macos-15-intel', 'ubuntu-24.04']"
       swift-android-sdk-version: "['', 'nightly-main']"
       # disable export because there are currently problems with shared PCH module cache files with multi-module native export

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip.git", from: "1.8.17"),
         .package(url: "https://source.skip.tools/skip-lib.git", from: "1.4.0"),
         .package(url: "https://source.skip.tools/skip-foundation.git", from: "1.4.0"),
-        .package(url: "https://source.skip.tools/swift-jni.git", "0.5.0"..<"2.0.0"),
+        .package(url: "https://source.skip.tools/swift-jni.git", branch: "main"), // FIXME
+        //.package(url: "https://source.skip.tools/swift-jni.git", "0.5.0"..<"2.0.0"),
     ],
     targets: [
         .target(name: "SkipBridge",

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,10 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 import PackageDescription
+
+// JNI bridge code manages its own thread/isolation invariants and cannot be expressed
+// under Swift 6 strict concurrency without a deep refactor. Compile every target in
+// Swift 5 language mode so strict-concurrency diagnostics revert to opt-in.
+let opt_out_of_strict_concurrency: [SwiftSetting] = [.swiftLanguageMode(.v5)]
 
 let package = Package(
     name: "skip-bridge",
@@ -22,33 +27,43 @@ let package = Package(
     targets: [
         .target(name: "SkipBridge",
             dependencies: [.product(name: "SwiftJNI", package: "swift-jni"), .product(name: "SkipLib", package: "skip-lib")],
+            swiftSettings: opt_out_of_strict_concurrency,
             plugins: [.plugin(name: "skipstone", package: "skip")]),
         .target(name: "SkipBridgeToKotlinSamples",
             dependencies: ["SkipBridgeToKotlinSamplesHelpers"],
+            swiftSettings: opt_out_of_strict_concurrency,
             plugins: [.plugin(name: "skipstone", package: "skip")]),
         .target(name: "SkipBridgeToKotlinSamplesHelpers",
             dependencies: ["SkipBridge", .product(name: "SkipFoundation", package: "skip-foundation")],
-                plugins: [.plugin(name: "skipstone", package: "skip")]),
+            swiftSettings: opt_out_of_strict_concurrency,
+            plugins: [.plugin(name: "skipstone", package: "skip")]),
         .target(name: "SkipBridgeToKotlinCompatSamples",
             dependencies: ["SkipBridge", .product(name: "SkipFoundation", package: "skip-foundation")],
+            swiftSettings: opt_out_of_strict_concurrency,
             plugins: [.plugin(name: "skipstone", package: "skip")]),
         .target(name: "SkipBridgeToSwiftSamples",
             dependencies: ["SkipBridgeToSwiftSamplesHelpers"],
+            swiftSettings: opt_out_of_strict_concurrency,
             plugins: [.plugin(name: "skipstone", package: "skip")]),
         .target(name: "SkipBridgeToSwiftSamplesHelpers",
             dependencies: ["SkipBridge", .product(name: "SkipFoundation", package: "skip-foundation")],
-                plugins: [.plugin(name: "skipstone", package: "skip")]),
+            swiftSettings: opt_out_of_strict_concurrency,
+            plugins: [.plugin(name: "skipstone", package: "skip")]),
         .target(name: "SkipBridgeToSwiftSamplesTestsSupport",
             dependencies: ["SkipBridgeToSwiftSamples"],
-                plugins: [.plugin(name: "skipstone", package: "skip")]),
+            swiftSettings: opt_out_of_strict_concurrency,
+            plugins: [.plugin(name: "skipstone", package: "skip")]),
         .testTarget(name: "SkipBridgeToKotlinSamplesTests",
             dependencies: ["SkipBridgeToKotlinSamples", .product(name: "SkipTest", package: "skip")],
+            swiftSettings: opt_out_of_strict_concurrency,
             plugins: [.plugin(name: "skipstone", package: "skip")]),
         .testTarget(name: "SkipBridgeToKotlinCompatSamplesTests",
             dependencies: ["SkipBridgeToKotlinCompatSamples", .product(name: "SkipTest", package: "skip")],
+            swiftSettings: opt_out_of_strict_concurrency,
             plugins: [.plugin(name: "skipstone", package: "skip")]),
         .testTarget(name: "SkipBridgeToSwiftSamplesTestsSupportTests",
             dependencies: ["SkipBridgeToSwiftSamplesTestsSupport", .product(name: "SkipTest", package: "skip")],
+            swiftSettings: opt_out_of_strict_concurrency,
             plugins: [.plugin(name: "skipstone", package: "skip")]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip.git", from: "1.8.17"),
         .package(url: "https://source.skip.tools/skip-lib.git", from: "1.4.0"),
         .package(url: "https://source.skip.tools/skip-foundation.git", from: "1.4.0"),
-        .package(url: "https://source.skip.tools/swift-jni.git", branch: "main"), // FIXME
+        .package(url: "https://source.skip.tools/swift-jni.git", branch: "jni-updates"), // FIXME
         //.package(url: "https://source.skip.tools/swift-jni.git", "0.5.0"..<"2.0.0"),
     ],
     targets: [

--- a/Sources/SkipBridge/Closures.swift
+++ b/Sources/SkipBridge/Closures.swift
@@ -1,6 +1,9 @@
 // Copyright 2024–2026 Skip
 // SPDX-License-Identifier: MPL-2.0
 import SwiftJNI
+#if canImport(SwiftJavaJNICore)
+import SwiftJavaJNICore
+#endif
 
 /// A Swift object that is backed by a Java closure in the form of a `kotlin.jvm.functions.FunctionN` object.
 public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
@@ -10,6 +13,13 @@ public final class JavaBackedClosure<R>: JObject, @unchecked Sendable {
         self.options = options
         super.init(ptr)
     }
+
+    #if canImport(SwiftJavaJNICore)
+    public required init(fromJNI value: JavaObjectPointer?, in environment: JNIEnvironment) {
+        self.options = []
+        super.init(JNI.jni.newGlobalRef(value!)!)
+    }
+    #endif
 
     public func invoke() throws -> R {
         return try jniContext {


### PR DESCRIPTION
This PR builds on https://github.com/skiptools/swift-jni/pull/6 to add a check for the `SWIFT_JAVA_JNI_CORE` environment variable, in which case it will use https://github.com/swiftlang/swift-java-jni-core as the underlying JNI implementation.

Once all fuse packages have equivalent parallel testing and validation for the `SWIFT_JAVA_JNI_CORE` mode than we can consider switching everything over wholesale.